### PR TITLE
Fix validator panicking if it has no balance, make `cargo clippy` happy

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4090,6 +4090,7 @@ dependencies = [
  "rusoto_sts",
  "serde",
  "serde_json",
+ "solana-sdk",
  "static_assertions",
  "tempfile",
  "thiserror",

--- a/rust/agents/relayer/src/msg/gas_payment/mod.rs
+++ b/rust/agents/relayer/src/msg/gas_payment/mod.rs
@@ -7,7 +7,7 @@ use hyperlane_core::{
     GasPaymentKey, HyperlaneMessage, InterchainGasExpenditure, InterchainGasPayment,
     TxCostEstimate, TxOutcome, U256,
 };
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, trace};
 
 use self::policies::{GasPaymentPolicyMinimum, GasPaymentPolicyNone};
 use crate::{

--- a/rust/agents/relayer/src/msg/metadata/multisig/message_id_multisig.rs
+++ b/rust/agents/relayer/src/msg/metadata/multisig/message_id_multisig.rs
@@ -7,7 +7,7 @@ use derive_new::new;
 use eyre::{Context, Result};
 use hyperlane_base::MultisigCheckpointSyncer;
 use hyperlane_core::{unwrap_or_none_result, HyperlaneMessage, H256};
-use tracing::{debug, trace, warn};
+use tracing::{debug, warn};
 
 use crate::msg::metadata::BaseMetadataBuilder;
 

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -1,11 +1,11 @@
 use std::num::NonZeroU64;
-use std::str::FromStr;
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::vec;
 
 use eyre::{bail, Result};
-use hyperlane_core::{MerkleTreeHook, H256};
+use hyperlane_core::MerkleTreeHook;
 use prometheus::IntGauge;
 use tokio::time::sleep;
 use tracing::{debug, info};

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -1,5 +1,4 @@
 use std::num::NonZeroU64;
-
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::vec;

--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -209,7 +209,12 @@ impl Validator {
     fn log_on_announce_failure(result: ChainResult<TxOutcome>) {
         match result {
             Ok(outcome) => {
-                if !outcome.executed {
+                if outcome.executed {
+                    info!(
+                        tx_outcome=?outcome,
+                        "Successfully announced validator",
+                    );
+                } else {
                     error!(
                         txid=?outcome.transaction_id,
                         gas_used=?outcome.gas_used,
@@ -221,7 +226,7 @@ impl Validator {
             Err(err) => {
                 error!(
                     ?err,
-                    "Failed to announce validator. Make sure you have enough ETH in your account to pay for gas."
+                    "Failed to announce validator. Make sure you have enough funds in your account to pay for gas."
                 );
             }
         }
@@ -229,13 +234,14 @@ impl Validator {
 
     async fn announce(&self) -> Result<()> {
         let address = self.signer.eth_address();
+        let announcement_location = self.checkpoint_syncer.announcement_location();
 
         // Sign and post the validator announcement
         let announcement = Announcement {
             validator: address,
             mailbox_address: self.mailbox.address(),
             mailbox_domain: self.mailbox.domain().id(),
-            storage_location: self.checkpoint_syncer.announcement_location(),
+            storage_location: announcement_location.clone(),
         };
         let signed_announcement = self.signer.sign(announcement.clone()).await?;
         self.checkpoint_syncer
@@ -255,8 +261,12 @@ impl Validator {
                 .await?
                 .first()
             {
-                if locations.contains(&self.checkpoint_syncer.announcement_location()) {
-                    info!("Validator has announced signature storage location");
+                if locations.contains(&announcement_location) {
+                    info!(
+                        ?locations,
+                        ?announcement_location,
+                        "Validator has announced signature storage location"
+                    );
                     break;
                 }
                 info!(
@@ -264,9 +274,9 @@ impl Validator {
                     "Validator has not announced signature storage location"
                 );
 
-                if self.core.settings.chains[self.origin_chain.name()]
-                    .signer
-                    .is_some()
+                if let Some(chain_signer) = self.core.settings.chains[self.origin_chain.name()]
+                    .chain_signer()
+                    .await?
                 {
                     let balance_delta = self
                         .validator_announce
@@ -276,8 +286,9 @@ impl Validator {
                     if balance_delta > U256::zero() {
                         warn!(
                             tokens_needed=%balance_delta,
-                            validator_address=?announcement.validator,
-                            "Please send tokens to the validator address to announce",
+                            eth_validator_address=?announcement.validator,
+                            chain_signer=?chain_signer.address(),
+                            "Please send tokens to your chain signer address to announce",
                         );
                     } else {
                         let result = self

--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -4,15 +4,13 @@ use async_trait::async_trait;
 use derive_more::AsRef;
 use eyre::Result;
 use futures_util::future::ready;
-use hyperlane_cosmos::verify::{priv_to_addr_string, priv_to_binary_addr};
+
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::{error, info, info_span, instrument::Instrumented, warn, Instrument};
 
 use hyperlane_base::{
     db::{HyperlaneRocksDB, DB},
-    run_all,
-    settings::SignerConf,
-    BaseAgent, CheckpointSyncer, ContractSyncMetrics, CoreMetrics, HyperlaneAgentCore,
+    run_all, BaseAgent, CheckpointSyncer, ContractSyncMetrics, CoreMetrics, HyperlaneAgentCore,
     WatermarkContractSync,
 };
 
@@ -45,7 +43,6 @@ pub struct Validator {
     reorg_period: u64,
     interval: Duration,
     checkpoint_syncer: Arc<dyn CheckpointSyncer>,
-    raw_signer: SignerConf,
 }
 
 #[async_trait]
@@ -104,7 +101,6 @@ impl BaseAgent for Validator {
             reorg_period: settings.reorg_period,
             interval: settings.interval,
             checkpoint_syncer,
-            raw_signer: settings.validator.clone(),
         })
     }
 
@@ -287,7 +283,7 @@ impl Validator {
                         warn!(
                             tokens_needed=%balance_delta,
                             eth_validator_address=?announcement.validator,
-                            chain_signer=?chain_signer.address(),
+                            chain_signer=?chain_signer.address_string(),
                             "Please send tokens to your chain signer address to announce",
                         );
                     } else {

--- a/rust/chains/hyperlane-cosmos/src/interchain_security_module.rs
+++ b/rust/chains/hyperlane-cosmos/src/interchain_security_module.rs
@@ -67,7 +67,6 @@ fn ism_type_to_module_type(ism_type: hpl_interface::ism::ISMType) -> ModuleType 
         hpl_interface::ism::ISMType::MessageIdMultisig => ModuleType::MessageIdMultisig,
         hpl_interface::ism::ISMType::Null => ModuleType::Null,
         hpl_interface::ism::ISMType::CcipRead => ModuleType::CcipRead,
-        _ => ModuleType::Null,
     }
 }
 

--- a/rust/chains/hyperlane-cosmos/src/mailbox.rs
+++ b/rust/chains/hyperlane-cosmos/src/mailbox.rs
@@ -305,7 +305,7 @@ impl Indexer<HyperlaneMessage> for CosmosMailboxIndexer {
         range: RangeInclusive<u32>,
     ) -> ChainResult<Vec<(HyperlaneMessage, LogMeta)>> {
         let parser = self.get_parser();
-        let mut result = self.indexer.get_range_event_logs(range, parser).await?;
+        let result = self.indexer.get_range_event_logs(range, parser).await?;
 
         Ok(result)
     }

--- a/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -121,8 +121,17 @@ impl WasmProvider for WasmGrpcProvider {
         let mut client = ServiceClient::connect(self.get_conn_url()?).await?;
         let request = tonic::Request::new(GetLatestBlockRequest {});
 
-        let response = client.get_latest_block(request).await.unwrap().into_inner();
-        let height = response.block.unwrap().header.unwrap().height;
+        let response = client
+            .get_latest_block(request)
+            .await
+            .map_err(ChainCommunicationError::from_other)?
+            .into_inner();
+        let height = response
+            .block
+            .ok_or_else(|| ChainCommunicationError::from_other_str("block not present"))?
+            .header
+            .ok_or_else(|| ChainCommunicationError::from_other_str("header not present"))?
+            .height;
 
         Ok(height as u64)
     }
@@ -147,13 +156,11 @@ impl WasmProvider for WasmGrpcProvider {
                 .insert("x-cosmos-block-height", height.into());
         }
 
-        let result = client.smart_contract_state(request).await;
-
-        if let Err(e) = result {
-            return Err(ChainCommunicationError::InvalidRequest { msg: e.to_string() });
-        }
-
-        let response = result.unwrap().into_inner();
+        let response = client
+            .smart_contract_state(request)
+            .await
+            .map_err(ChainCommunicationError::from_other)?
+            .into_inner();
 
         // TODO: handle query to specific block number
         Ok(response.data)
@@ -183,13 +190,11 @@ impl WasmProvider for WasmGrpcProvider {
                 .insert("x-cosmos-block-height", height.into());
         }
 
-        let result = client.smart_contract_state(request).await;
-
-        if let Err(e) = result {
-            return Err(ChainCommunicationError::InvalidRequest { msg: e.to_string() });
-        }
-
-        let response = result.unwrap().into_inner();
+        let response = client
+            .smart_contract_state(request)
+            .await
+            .map_err(ChainCommunicationError::from_other)?
+            .into_inner();
 
         // TODO: handle query to specific block number
         Ok(response.data)
@@ -199,9 +204,19 @@ impl WasmProvider for WasmGrpcProvider {
         let mut client = QueryAccountClient::connect(self.get_conn_url()?).await?;
 
         let request = tonic::Request::new(QueryAccountRequest { address: account });
-        let response = client.account(request).await.unwrap().into_inner();
+        let response = client
+            .account(request)
+            .await
+            .map_err(ChainCommunicationError::from_other)?
+            .into_inner();
 
-        let account = BaseAccount::decode(response.account.unwrap().value.as_slice())?;
+        let account = BaseAccount::decode(
+            response
+                .account
+                .ok_or_else(|| ChainCommunicationError::from_other_str("account not present"))?
+                .value
+                .as_slice(),
+        )?;
         Ok(account)
     }
 
@@ -217,7 +232,11 @@ impl WasmProvider for WasmGrpcProvider {
 
         let tx_bytes = self.generate_raw_tx(msgs, gas_limit).await?;
         let sim_req = tonic::Request::new(SimulateRequest { tx: None, tx_bytes });
-        let mut sim_res = client.simulate(sim_req).await.unwrap().into_inner();
+        let mut sim_res = client
+            .simulate(sim_req)
+            .await
+            .map_err(ChainCommunicationError::from_other)?
+            .into_inner();
 
         // apply gas adjustment
         sim_res.gas_info.as_mut().map(|v| {
@@ -240,16 +259,13 @@ impl WasmProvider for WasmGrpcProvider {
         let tx_body = tx::Body::new(msgs, "", 9000000u32);
         let signer_info = SignerInfo::single_direct(Some(public_key), account_info.sequence);
 
-        let gas_limit: u64 = gas_limit
-            .unwrap_or(U256::from_str("100000").unwrap())
-            .as_u64();
+        let gas_limit: u64 = gas_limit.unwrap_or(U256::from(100000u64)).as_u64();
 
         let auth_info = signer_info.auth_info(Fee::from_amount_and_gas(
             Coin::new(
                 Amount::from((gas_limit as f32 * DEFAULT_GAS_PRICE) as u64),
                 self.conf.get_canonical_asset().as_str(),
-            )
-            .unwrap(),
+            )?,
             gas_limit,
         ));
 
@@ -257,14 +273,13 @@ impl WasmProvider for WasmGrpcProvider {
         let sign_doc = SignDoc::new(
             &tx_body,
             &auth_info,
-            &self.conf.get_chain_id().parse().unwrap(),
+            &self.conf.get_chain_id().parse()?,
             account_info.account_number,
-        )
-        .unwrap();
+        )?;
 
-        let tx_signed = sign_doc.sign(&private_key).unwrap();
+        let tx_signed = sign_doc.sign(&private_key)?;
 
-        Ok(tx_signed.to_bytes().unwrap())
+        Ok(tx_signed.to_bytes()?)
     }
 
     async fn wasm_send<T>(&self, payload: T, gas_limit: Option<U256>) -> ChainResult<TxResponse>
@@ -280,7 +295,7 @@ impl WasmProvider for WasmGrpcProvider {
             funds: vec![],
         }
         .to_any()
-        .unwrap()];
+        .map_err(ChainCommunicationError::from_other)?];
 
         let tx_req = BroadcastTxRequest {
             tx_bytes: self.generate_raw_tx(msgs, gas_limit).await?,
@@ -293,7 +308,7 @@ impl WasmProvider for WasmGrpcProvider {
             .unwrap()
             .into_inner()
             .tx_response
-            .unwrap();
+            .ok_or_else(|| ChainCommunicationError::from_other_str("Empty tx_response"))?;
         if tx_res.code != 0 {
             println!("TX_ERROR: {}", tx_res.raw_log);
         }
@@ -313,7 +328,10 @@ impl WasmProvider for WasmGrpcProvider {
         };
 
         let response = self
-            .simulate_raw_tx(vec![msg.to_any().unwrap()], None)
+            .simulate_raw_tx(
+                vec![msg.to_any().map_err(ChainCommunicationError::from_other)?],
+                None,
+            )
             .await?;
 
         Ok(response)

--- a/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -18,7 +18,6 @@ use cosmrs::proto::cosmwasm::wasm::v1::{
 };
 use cosmrs::proto::traits::Message;
 
-use cosmrs::tendermint::chain;
 use cosmrs::tx::{self, Fee, MessageExt, SignDoc, SignerInfo};
 use cosmrs::{Amount, Coin};
 use hyperlane_core::{
@@ -26,7 +25,6 @@ use hyperlane_core::{
 };
 use serde::Serialize;
 use std::num::NonZeroU64;
-use std::str::FromStr;
 
 use crate::verify;
 use crate::{signers::Signer, ConnectionConf};
@@ -90,7 +88,7 @@ pub trait WasmProvider: Send + Sync {
 /// Cosmwasm GRPC Provider
 pub struct WasmGrpcProvider {
     conf: ConnectionConf,
-    domain: HyperlaneDomain,
+    _domain: HyperlaneDomain,
     address: H256,
     signer: Signer,
 }
@@ -100,7 +98,7 @@ impl WasmGrpcProvider {
     pub fn new(conf: ConnectionConf, locator: ContractLocator, signer: Signer) -> Self {
         Self {
             conf,
-            domain: locator.domain.clone(),
+            _domain: locator.domain.clone(),
             address: locator.address,
             signer,
         }
@@ -231,6 +229,7 @@ impl WasmProvider for WasmGrpcProvider {
         let mut client = TxServiceClient::connect(self.get_conn_url()?).await?;
 
         let tx_bytes = self.generate_raw_tx(msgs, gas_limit).await?;
+        #[allow(deprecated)]
         let sim_req = tonic::Request::new(SimulateRequest { tx: None, tx_bytes });
         let mut sim_res = client
             .simulate(sim_req)

--- a/rust/chains/hyperlane-cosmos/src/providers/rpc.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/rpc.rs
@@ -2,7 +2,7 @@ use std::ops::RangeInclusive;
 
 use crate::binary::h256_to_h512;
 use async_trait::async_trait;
-use cosmrs::rpc::client::{Client, CompatMode, HttpClient};
+use cosmrs::rpc::client::{Client, HttpClient};
 use cosmrs::rpc::endpoint::tx;
 use cosmrs::rpc::query::Query;
 use cosmrs::rpc::Order;
@@ -44,7 +44,7 @@ pub trait WasmIndexer: Send + Sync {
 /// Cosmwasm RPC Provider
 pub struct CosmosWasmIndexer {
     conf: ConnectionConf,
-    domain: HyperlaneDomain,
+    _domain: HyperlaneDomain,
     address: H256,
     event_type: String,
 }
@@ -56,7 +56,7 @@ impl CosmosWasmIndexer {
     pub fn new(conf: ConnectionConf, locator: ContractLocator, event_type: String) -> Self {
         Self {
             conf,
-            domain: locator.domain.clone(),
+            _domain: locator.domain.clone(),
             address: locator.address,
             event_type,
         }

--- a/rust/chains/hyperlane-cosmos/src/validator_announce.rs
+++ b/rust/chains/hyperlane-cosmos/src/validator_announce.rs
@@ -115,11 +115,8 @@ impl ValidatorAnnounce for CosmosValidatorAnnounce {
     }
 
     async fn announce_tokens_needed(&self, announcement: SignedType<Announcement>) -> Option<U256> {
-        let out = self
-            .announce(announcement, None)
-            .await
-            .expect("failed to announce");
-
-        None
+        // TODO: check user balance. For now, just try announcing and
+        // allow the announce attempt to fail if there are not enough tokens.
+        Some(0u64.into())
     }
 }

--- a/rust/chains/hyperlane-ethereum/tests/signer_output.rs
+++ b/rust/chains/hyperlane-ethereum/tests/signer_output.rs
@@ -7,7 +7,6 @@ use std::{fs::OpenOptions, io::Write, str::FromStr};
 use hex::FromHex;
 use serde_json::{json, Value};
 
-use ethers::signers::Signer;
 use hyperlane_core::{
     accumulator::{
         merkle::{merkle_root_from_branch, MerkleTree},
@@ -15,7 +14,7 @@ use hyperlane_core::{
     },
     test_utils,
     utils::domain_hash,
-    Checkpoint, HyperlaneMessage, HyperlaneSignerExt, H160, H256,
+    HyperlaneMessage, H160, H256,
 };
 
 /// Output proof to /vector/message.json

--- a/rust/hyperlane-base/Cargo.toml
+++ b/rust/hyperlane-base/Cargo.toml
@@ -27,6 +27,7 @@ prometheus.workspace = true
 rocksdb.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+solana-sdk.worksapce = true
 static_assertions.workspace = true
 tempfile = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/rust/hyperlane-base/src/settings/signers.rs
+++ b/rust/hyperlane-base/src/settings/signers.rs
@@ -51,7 +51,7 @@ impl SignerConf {
 /// A signer for a chain.
 pub trait ChainSigner: Send {
     /// The address of the signer, formatted in the chain's own address format.
-    fn address(&self) -> String;
+    fn address_string(&self) -> String;
 }
 
 /// Builder trait for signers
@@ -86,7 +86,7 @@ impl BuildableWithSignerConf for hyperlane_ethereum::Signers {
                 let signer = AwsSigner::new(client, id, 0).await?;
                 hyperlane_ethereum::Signers::Aws(signer)
             }
-            SignerConf::CosmosKey { key, .. } => {
+            SignerConf::CosmosKey { .. } => {
                 bail!("cosmosKey signer is not supported by Ethereum")
             }
             SignerConf::Node => bail!("Node signer"),
@@ -95,8 +95,8 @@ impl BuildableWithSignerConf for hyperlane_ethereum::Signers {
 }
 
 impl ChainSigner for hyperlane_ethereum::Signers {
-    fn address(&self) -> String {
-        self.address().to_string()
+    fn address_string(&self) -> String {
+        ethers::signers::Signer::address(self).to_string()
     }
 }
 
@@ -117,7 +117,7 @@ impl BuildableWithSignerConf for fuels::prelude::WalletUnlocked {
 }
 
 impl ChainSigner for fuels::prelude::WalletUnlocked {
-    fn address(&self) -> String {
+    fn address_string(&self) -> String {
         self.address().to_string()
     }
 }
@@ -140,7 +140,7 @@ impl BuildableWithSignerConf for Keypair {
 }
 
 impl ChainSigner for Keypair {
-    fn address(&self) -> String {
+    fn address_string(&self) -> String {
         solana_sdk::signer::Signer::pubkey(self).to_string()
     }
 }
@@ -160,7 +160,7 @@ impl BuildableWithSignerConf for hyperlane_cosmos::Signer {
 }
 
 impl ChainSigner for hyperlane_cosmos::Signer {
-    fn address(&self) -> String {
+    fn address_string(&self) -> String {
         self.address()
     }
 }

--- a/rust/hyperlane-core/src/error.rs
+++ b/rust/hyperlane-core/src/error.rs
@@ -93,6 +93,10 @@ pub enum ChainCommunicationError {
     /// Cosmrs library error
     #[error("{0}")]
     Cosmrs(#[from] CosmrsError),
+    #[error("{0}")]
+    CosmrsErrorReport(#[from] cosmrs::ErrorReport),
+    #[error("{0}")]
+    CosmrsTendermintError(#[from] cosmrs::tendermint::Error),
     /// Tonic error
     #[error("{0}")]
     Tonic(#[from] tonic::transport::Error),

--- a/rust/hyperlane-core/src/error.rs
+++ b/rust/hyperlane-core/src/error.rs
@@ -93,9 +93,11 @@ pub enum ChainCommunicationError {
     /// Cosmrs library error
     #[error("{0}")]
     Cosmrs(#[from] CosmrsError),
+    /// Cosmrs ErrorReport
     #[error("{0}")]
     CosmrsErrorReport(#[from] cosmrs::ErrorReport),
     #[error("{0}")]
+    /// Cosmrs Tendermint Error
     CosmrsTendermintError(#[from] cosmrs::tendermint::Error),
     /// Tonic error
     #[error("{0}")]

--- a/rust/neutron_validator_config.json
+++ b/rust/neutron_validator_config.json
@@ -6,8 +6,7 @@
   },
   "originChainName": "neutrontestnet",
   "validator": {
-    "signerType": "cosmosKey",
-    "key": "0xac30d9f8ba63095774e7c853e23b02768031aa5076576113bbc9f4f07f4d12c5",
-    "prefix": "dual"
+    "signerType": "hexKey",
+    "key": "0xac30d9f8ba63095774e7c853e23b02768031aa5076576113bbc9f4f07f4d12c5"
   }
 }

--- a/rust/utils/run-locally/src/cosmos/cli.rs
+++ b/rust/utils/run-locally/src/cosmos/cli.rs
@@ -3,7 +3,6 @@ use std::{collections::BTreeMap, io::Write, path::PathBuf, process::Stdio};
 use k256::ecdsa::SigningKey;
 
 use crate::{
-    cosmos::types::CliWasmQueryResponse,
     program::Program,
     utils::{concat_path, AgentHandles, TaskHandle},
 };

--- a/rust/utils/run-locally/src/cosmos/link.rs
+++ b/rust/utils/run-locally/src/cosmos/link.rs
@@ -1,4 +1,3 @@
-use ::core::panic;
 use std::path::Path;
 
 use cosmwasm_schema::cw_serde;
@@ -93,7 +92,7 @@ fn link_network(
     target_domain: u32,
 ) {
     let validator_addr = validator.addr(hrp);
-    let validator_pubkey = validator.pub_key_to_binary();
+    let _validator_pubkey = validator.pub_key_to_binary();
 
     let dest_domain = if network.domain == 26657 {
         26658

--- a/rust/utils/run-locally/src/cosmos/mod.rs
+++ b/rust/utils/run-locally/src/cosmos/mod.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use std::{env, fs};
 
 use cosmwasm_schema::cw_serde;
-use hpl_interface::{core, types::bech32_decode};
+use hpl_interface::types::bech32_decode;
 use macro_rules_attribute::apply;
 use tempfile::tempdir;
 
@@ -132,7 +132,7 @@ pub fn install_cosmos(
     cli_dir: Option<PathBuf>,
     cli_src: Option<CLISource>,
     codes_dir: Option<PathBuf>,
-    codes_src: Option<CodeSource>,
+    _codes_src: Option<CodeSource>,
 ) -> (PathBuf, BTreeMap<String, PathBuf>) {
     let osmosisd = cli_src
         .unwrap_or(CLISource::Remote {

--- a/rust/utils/run-locally/src/cosmos/source.rs
+++ b/rust/utils/run-locally/src/cosmos/source.rs
@@ -86,6 +86,7 @@ impl CodeSource {
             .collect()
     }
 
+    #[allow(dead_code)]
     pub fn install(self, dir: Option<PathBuf>) -> BTreeMap<String, PathBuf> {
         match self {
             CodeSource::Local { path } => Self::install_local(path),


### PR DESCRIPTION
### Description

* Noticed that the validator would panic if the signer didn't have any tokens - this was because `announce_tokens_needed` was performing an announce, and because there were some unwraps in the GRPCs. The fix was to get rid of the unwraps and to have announce_tokens_needed just return 0 for now - the intent of it is to just submit an announcement if the balance is high enough, but it's also valid to just rely on the `announce` call failing
* Started logging the validator's chain signer as well
* Made some changes to make `cargo clippy` happy
* Changed the validator config to be a hexKey as it doesn't need to be a cosmwasm key (and really shouldn't be, as it's more eth related)

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

n/a

### Testing

Ran the validator locally