### PR TITLE
Estimate gas usage when announcing

### DIFF
--- a/rust/chains/hyperlane-cosmos/src/validator_announce.rs
+++ b/rust/chains/hyperlane-cosmos/src/validator_announce.rs
@@ -2,8 +2,9 @@ use async_trait::async_trait;
 
 use cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse;
 use hyperlane_core::{
-    Announcement, ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
-    HyperlaneProvider, SignedType, TxOutcome, ValidatorAnnounce, H256, U256,
+    Announcement, ChainCommunicationError, ChainResult, ContractLocator, HyperlaneChain,
+    HyperlaneContract, HyperlaneDomain, HyperlaneProvider, SignedType, TxOutcome,
+    ValidatorAnnounce, H256, U256,
 };
 
 use crate::{
@@ -100,9 +101,25 @@ impl ValidatorAnnounce for CosmosValidatorAnnounce {
             },
         };
 
+        // Perform gas estimation if a limit wasn't already provided.
+        // TODO: refactor `wasm_send` to do this gas estimation automatically
+        // instead of using a default hardcoded value if the gas limit is `None`.
+        let tx_gas_limit = if let Some(gas_limit) = tx_gas_limit {
+            gas_limit
+        } else {
+            // A multiplier is applied already for us
+            self.provider
+                .wasm_simulate(announce_request.clone())
+                .await?
+                .gas_info
+                .ok_or_else(|| ChainCommunicationError::from_other_str("gas info not present"))?
+                .gas_used
+                .into()
+        };
+
         let response: TxResponse = self
             .provider
-            .wasm_send(announce_request, tx_gas_limit)
+            .wasm_send(announce_request, Some(tx_gas_limit))
             .await?;
 
         Ok(TxOutcome {


### PR DESCRIPTION
### Description

Ran into an issue when running with longer storage location names where the default 100k gas amount wasn't enough when performing an `announce` tx. Added simulating the gas costs. I think ideally we'll change grpc.rs at some point to do the gas estimation instead of falling back to a hardcoded amount, but this can wait for now

### Drive-by changes

* As simulation doesn't honor the gas amount, removed the tx gas limit param from `simulate_raw_tx`
* Bumped the default fallback amount to 300k

### Related issues

n/a

### Backward compatibility

n/a

### Testing

Ran it
